### PR TITLE
Auto-select link text on all platforms

### DIFF
--- a/src/components/ShareBar.vue
+++ b/src/components/ShareBar.vue
@@ -15,7 +15,7 @@
             class="share-url"
             v-model="shareURL"
             placeholder="Shareable link not ready"
-            @focus="$event.target.select()"
+            @click="selectLinkText"
             readonly
           />
           <b-input-group-append>
@@ -114,6 +114,9 @@ export default {
     this.watchForDataChange();
   },
   methods: {
+    selectLinkText(event) {
+      event.target.setSelectionRange(0, event.target.value.length);
+    },
     updateShareURL: _.debounce(function() {
       const compressed = LZ.compressToEncodedURIComponent(JSON.stringify({
         s: this.schema,


### PR DESCRIPTION
Safari doesn't support the `#select()` method for inputs. The
alternative is to set the selection range for the input to the whole
length of the input text.

Closes #4