### PR TITLE
TEST - Make share URL input readonly

### DIFF
--- a/src/components/ShareBar.vue
+++ b/src/components/ShareBar.vue
@@ -12,9 +12,11 @@
             />
           </b-input-group-text>
           <b-form-input
+            class="share-url"
             v-model="shareURL"
             placeholder="Shareable link not ready"
             @focus="$event.target.select()"
+            readonly
           />
           <b-input-group-append>
             <b-button variant="outline-dark" @click="copyLink()">
@@ -148,3 +150,9 @@ export default {
   },
 }
 </script>
+
+<style>
+  .share-url:read-only {
+    background-color: white;
+  }
+</style>


### PR DESCRIPTION
As this value is generated it doesn’t make sense for the user to be able to edit it.