### PR TITLE
Display uncaught errors during validation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,17 +49,17 @@
           <b-alert v-else-if="ajvSchemaError.length !== 0" show variant="danger">
             JSON Schema invalid. Scroll for errors.
           </b-alert>
-          <b-alert v-else-if="uncaughtError !== null" show variant="danger">
-            {{ uncaughtError }}
-          </b-alert>
           <b-alert v-else-if="ajvValidationSuccess === null" show variant="info">
             Checking validation
           </b-alert>
           <b-alert v-if="ajvValidationSuccess === true" show variant="success">
             Instance Validation Successful
           </b-alert>
-          <b-alert v-if="ajvValidationSuccess === false" show variant="danger">
+          <b-alert v-if="ajvValidationSuccess === false && uncaughtError === null" show variant="danger">
             Instance Validation Failed. Scroll for errors.
+          </b-alert>
+          <b-alert v-else-if="ajvValidationSuccess === false && uncaughtError !== null" show variant="danger">
+            {{ uncaughtError }}
           </b-alert>
         </b-col>
       </b-row>
@@ -338,6 +338,7 @@ export default {
         this.validate().catch(error => {
           // Catch errors that aren't directly related to validation, so we can
           // show them to the user.
+          this.ajvValidationSuccess = false;
           this.uncaughtError = error;
         });
       }


### PR DESCRIPTION
For issues like #1 where there's an uncaught error during validation, the UI's top alert gets stuck at "Checking validation" without any indication that something went wrong.

This PR makes it so uncaught errors are displayed to users instead of getting stuck in a "loading" state.

(Let me know if there's anything you want me to change. I'm happy to make any adjustments you feel are necessary.)